### PR TITLE
feat: Add centralized configuration and replace magic numbers

### DIFF
--- a/mcp_server_oci/config.py
+++ b/mcp_server_oci/config.py
@@ -1,0 +1,127 @@
+"""
+Configuration constants for MCP OCI Server.
+
+This module centralizes all configuration values, magic numbers, and defaults
+to make them easily discoverable and modifiable.
+"""
+
+# ============================================================================
+# Server Configuration
+# ============================================================================
+
+# Default port for SSE (Server-Sent Events) transport
+DEFAULT_SSE_PORT = 45678
+
+# Default log level for the server
+DEFAULT_LOG_LEVEL = "INFO"
+
+# Default OCI CLI profile name
+DEFAULT_OCI_PROFILE = "DEFAULT"
+
+
+# ============================================================================
+# SSH Key Generation
+# ============================================================================
+
+# Default SSH key size in bits (RSA)
+DEFAULT_SSH_KEY_SIZE = 2048
+
+# Public exponent for RSA key generation (standard value)
+RSA_PUBLIC_EXPONENT = 65537
+
+# Default comment for generated SSH keys
+DEFAULT_SSH_KEY_COMMENT = "oci-mcp-server-key"
+
+
+# ============================================================================
+# File Permissions
+# ============================================================================
+
+# Unix file permissions for private SSH keys (owner read/write only)
+PRIVATE_KEY_PERMISSIONS = 0o600
+
+
+# ============================================================================
+# HTTP Status Codes (for error handling)
+# ============================================================================
+
+HTTP_NOT_FOUND = 404
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+HTTP_INTERNAL_ERROR = 500
+
+
+# ============================================================================
+# OCI Resource States
+# ============================================================================
+
+# Compute Instance States
+class InstanceState:
+    """OCI Compute Instance lifecycle states."""
+    PROVISIONING = "PROVISIONING"
+    RUNNING = "RUNNING"
+    STARTING = "STARTING"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
+    CREATING_IMAGE = "CREATING_IMAGE"
+    TERMINATING = "TERMINATING"
+    TERMINATED = "TERMINATED"
+
+
+# DB Node States
+class DBNodeState:
+    """OCI Database Node lifecycle states."""
+    PROVISIONING = "PROVISIONING"
+    AVAILABLE = "AVAILABLE"
+    UPDATING = "UPDATING"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
+    STARTING = "STARTING"
+    TERMINATING = "TERMINATING"
+    TERMINATED = "TERMINATED"
+    FAILED = "FAILED"
+
+
+# Compartment States
+class CompartmentState:
+    """OCI Compartment lifecycle states."""
+    CREATING = "CREATING"
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
+    DELETING = "DELETING"
+    DELETED = "DELETED"
+
+
+# ============================================================================
+# OCI API Configuration
+# ============================================================================
+
+# Default timeout for OCI API calls (None means use SDK default)
+OCI_API_TIMEOUT = None
+
+# Retry configuration
+OCI_MAX_RETRIES = 3
+OCI_RETRY_BACKOFF_FACTOR = 2  # Exponential backoff multiplier
+
+
+# ============================================================================
+# Pagination
+# ============================================================================
+
+# Default page size for list operations
+DEFAULT_PAGE_SIZE = 100
+
+# Maximum results to return (None for unlimited)
+MAX_RESULTS = None
+
+
+# ============================================================================
+# Resource Naming
+# ============================================================================
+
+# Prefix for temporary resources created by MCP server
+TEMP_RESOURCE_PREFIX = "mcp_temp_"
+
+# Tag key for resources managed by MCP
+MCP_MANAGED_TAG_KEY = "mcp-managed"
+MCP_MANAGED_TAG_VALUE = "true"

--- a/mcp_server_oci/mcp_server.py
+++ b/mcp_server_oci/mcp_server.py
@@ -12,6 +12,11 @@ import oci
 from loguru import logger
 
 from mcp.server.fastmcp import FastMCP, Context
+from mcp_server_oci.config import (
+    DEFAULT_SSE_PORT,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_OCI_PROFILE,
+)
 
 # Import OCI tools
 from mcp_server_oci.tools.compartments import list_compartments
@@ -99,7 +104,7 @@ from mcp_server_oci.tools.dbsystems import (
 
 # Setup logging
 logger.remove()
-log_level = os.environ.get("FASTMCP_LOG_LEVEL", "INFO")
+log_level = os.environ.get("FASTMCP_LOG_LEVEL", DEFAULT_LOG_LEVEL)
 logger.add(sys.stderr, level=log_level)
 
 # Create the MCP server
@@ -423,10 +428,10 @@ def main() -> None:
         description="A Model Context Protocol (MCP) server for Oracle Cloud Infrastructure"
     )
 
-    parser.add_argument("--profile", default=os.environ.get("OCI_CLI_PROFILE", "DEFAULT"),
+    parser.add_argument("--profile", default=os.environ.get("OCI_CLI_PROFILE", DEFAULT_OCI_PROFILE),
                         help="OCI profile to use")
     parser.add_argument("--sse", action="store_true", help="Use SSE transport")
-    parser.add_argument("--port", type=int, default=45678, help="Port for SSE transport")
+    parser.add_argument("--port", type=int, default=DEFAULT_SSE_PORT, help="Port for SSE transport")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     args = parser.parse_args()
 

--- a/mcp_server_oci/utils.py
+++ b/mcp_server_oci/utils.py
@@ -11,10 +11,17 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 
+from mcp_server_oci.config import (
+    DEFAULT_SSH_KEY_SIZE,
+    RSA_PUBLIC_EXPONENT,
+    DEFAULT_SSH_KEY_COMMENT,
+    PRIVATE_KEY_PERMISSIONS,
+)
+
 logger = logging.getLogger(__name__)
 
 
-def generate_ssh_key_pair(key_size: int = 2048, comment: str = "oci-mcp-server-key") -> Tuple[str, str]:
+def generate_ssh_key_pair(key_size: int = DEFAULT_SSH_KEY_SIZE, comment: str = DEFAULT_SSH_KEY_COMMENT) -> Tuple[str, str]:
     """
     Generate a new SSH key pair.
     
@@ -28,7 +35,7 @@ def generate_ssh_key_pair(key_size: int = 2048, comment: str = "oci-mcp-server-k
     try:
         # Generate private key
         private_key = rsa.generate_private_key(
-            public_exponent=65537,
+            public_exponent=RSA_PUBLIC_EXPONENT,
             key_size=key_size,
             backend=default_backend()
         )
@@ -86,7 +93,7 @@ def save_ssh_key_pair(private_key: str, public_key: str,
             f.write(private_key)
             
         # Set appropriate permissions for private key
-        os.chmod(private_key_path, 0o600)
+        os.chmod(private_key_path, PRIVATE_KEY_PERMISSIONS)
         
         with open(public_key_path, 'w') as f:
             f.write(public_key)


### PR DESCRIPTION
- Created mcp_server_oci/config.py with all configuration constants
  - Server configuration (DEFAULT_SSE_PORT, DEFAULT_LOG_LEVEL, DEFAULT_OCI_PROFILE)
  - SSH key configuration (DEFAULT_SSH_KEY_SIZE, RSA_PUBLIC_EXPONENT, DEFAULT_SSH_KEY_COMMENT)
  - File permissions (PRIVATE_KEY_PERMISSIONS)
  - OCI resource state classes (InstanceState, DBNodeState, CompartmentState)
  - API configuration, pagination settings, resource naming

- Updated mcp_server.py to use constants from config.py:
  - DEFAULT_LOG_LEVEL for logging setup
  - DEFAULT_OCI_PROFILE for argparse profile default
  - DEFAULT_SSE_PORT for argparse port default

- Updated utils.py to use constants from config.py:
  - DEFAULT_SSH_KEY_SIZE for generate_ssh_key_pair key_size parameter
  - RSA_PUBLIC_EXPONENT for RSA key generation
  - DEFAULT_SSH_KEY_COMMENT for SSH key comment
  - PRIVATE_KEY_PERMISSIONS for private key file permissions

This improves maintainability by centralizing all magic numbers and making configuration values easily discoverable and modifiable.