### PR TITLE
feat: Add database tools (4 new tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ Add this configuration to your file:
 - `start_instance` - Start a stopped instance
 - `stop_instance` - Stop a running instance (supports soft/force stop)
 
-### **Database Systems** 🔥
+### **Databases** 🔥
+#### DB Systems
 - `list_db_systems` - List DB Systems in a compartment
 - `get_db_system` - Get detailed DB System information
 - `list_db_nodes` - List DB Nodes in a compartment (optionally filtered by DB System)
@@ -167,6 +168,14 @@ Add this configuration to your file:
 - `softreset_db_node` - Soft reset (graceful reboot) a DB Node
 - `start_db_system` - Start all nodes of a DB System
 - `stop_db_system` - Stop all nodes of a DB System
+
+#### Regular Databases 🆕
+- `list_databases` - List databases in a compartment (optionally filtered by DB System)
+- `get_database` - Get detailed database information including connection strings and PDB name
+
+#### Autonomous Databases 🆕
+- `list_autonomous_databases` - List Autonomous Databases with workload type and connection info
+- `get_autonomous_database` - Get detailed ADB info including wallet info and auto-scaling settings
 
 ### **Networking**
 #### Virtual Cloud Networks (VCNs)
@@ -235,22 +244,31 @@ Add this configuration to your file:
 "Stop the instance ocid1.instance.oc1... with force stop"
 ```
 
-### **Database Systems Management**
+### **Database Management**
 ```bash
-# List DB Systems
+# DB Systems
 "Show me all DB Systems in compartment ocid1.compartment.oc1..."
-
-# Get DB System details
 "Get details for DB System ocid1.dbsystem.oc1..."
 
-# Manage DB Nodes
+# DB Nodes management
 "List all DB Nodes for DB System ocid1.dbsystem.oc1..."
 "Start DB Node ocid1.dbnode.oc1..."
 "Stop all nodes of DB System ocid1.dbsystem.oc1..."
-
-# Reboot operations
 "Reboot DB Node ocid1.dbnode.oc1..."
 "Soft reset DB Node ocid1.dbnode.oc1..."
+
+# Regular Databases 🆕
+"List all databases in compartment X"
+"Show me databases in DB System Y"
+"Get connection strings for database ocid1.database.oc1..."
+"What is the character set and PDB name of this database?"
+
+# Autonomous Databases 🆕
+"List all Autonomous Databases in compartment Z"
+"Show me details for ADB ocid1.autonomousdatabase.oc1..."
+"What workload type is this Autonomous Database?"
+"Get connection strings and wallet info for this ADB"
+"Is auto-scaling enabled on this Autonomous Database?"
 ```
 
 ### **Networking Management**
@@ -306,7 +324,15 @@ Add this configuration to your file:
 
 ## 🚀 **Recent Improvements**
 
-### v1.7 - Storage Tools (Latest) 💾
+### v1.8 - Database Tools (Latest) 🗄️
+- **4 new database tools**: Regular Databases and Autonomous Databases
+- **Regular Databases**: List/get databases with connection strings and PDB names
+- **Autonomous Databases**: List/get ADB with workload type, wallet info, and auto-scaling
+- Complete database ecosystem coverage: DB Systems, DB Nodes, Databases, and ADB
+- Total MCP tools increased from 38 to 42
+- Added comprehensive database usage examples in README
+
+### v1.7 - Storage Tools 💾
 - **9 new storage tools**: Object Storage, Block Storage, File Storage
 - **Object Storage**: Get namespace, list/get buckets with public access info
 - **Block Storage**: List/get volumes and boot volumes with performance tiers

--- a/mcp_server_oci/mcp_server.py
+++ b/mcp_server_oci/mcp_server.py
@@ -935,6 +935,83 @@ async def mcp_get_file_system(ctx: Context, file_system_id: str) -> Dict[str, An
     return get_file_system(oci_clients["file_storage"], file_system_id)
 
 
+# Database tools - Regular Databases
+@mcp.tool(name="list_databases")
+@mcp_tool_wrapper(
+    start_msg="Listing databases in compartment {compartment_id}...",
+    error_prefix="Error listing databases"
+)
+async def mcp_list_databases(ctx: Context, compartment_id: str, db_system_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    List all databases in a compartment, optionally filtered by DB System.
+
+    Args:
+        compartment_id: OCID of the compartment to list databases from
+        db_system_id: Optional OCID of the DB System to filter databases
+
+    Returns:
+        List of databases with their state, version, and connection information
+    """
+    return list_databases(oci_clients["database"], compartment_id, db_system_id)
+
+
+@mcp.tool(name="get_database")
+@mcp_tool_wrapper(
+    start_msg="Getting database details for {database_id}...",
+    success_msg="Retrieved database details successfully",
+    error_prefix="Error getting database details"
+)
+async def mcp_get_database(ctx: Context, database_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific database.
+
+    Args:
+        database_id: OCID of the database to retrieve
+
+    Returns:
+        Detailed database information including connection strings, character set, and PDB name
+    """
+    return get_database(oci_clients["database"], database_id)
+
+
+# Database tools - Autonomous Databases
+@mcp.tool(name="list_autonomous_databases")
+@mcp_tool_wrapper(
+    start_msg="Listing Autonomous Databases in compartment {compartment_id}...",
+    error_prefix="Error listing Autonomous Databases"
+)
+async def mcp_list_autonomous_databases(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all Autonomous Databases in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list Autonomous Databases from
+
+    Returns:
+        List of Autonomous Databases with their configuration, workload type, and connection info
+    """
+    return list_autonomous_databases(oci_clients["database"], compartment_id)
+
+
+@mcp.tool(name="get_autonomous_database")
+@mcp_tool_wrapper(
+    start_msg="Getting Autonomous Database details for {autonomous_database_id}...",
+    success_msg="Retrieved Autonomous Database details successfully",
+    error_prefix="Error getting Autonomous Database details"
+)
+async def mcp_get_autonomous_database(ctx: Context, autonomous_database_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific Autonomous Database.
+
+    Args:
+        autonomous_database_id: OCID of the Autonomous Database to retrieve
+
+    Returns:
+        Detailed Autonomous Database information including connection strings, wallet info, and auto-scaling settings
+    """
+    return get_autonomous_database(oci_clients["database"], autonomous_database_id)
+
+
 def main() -> None:
     """Run the MCP server for OCI."""
     global oci_clients, current_profile


### PR DESCRIPTION
Added 4 new MCP tools for database resources:

Regular Databases (2 tools):
- list_databases: List databases in compartment (filtered by DB System)
- get_database: Get detailed database info with connection strings and PDB name

Autonomous Databases (2 tools):
- list_autonomous_databases: List ADBs with workload type and connection info
- get_autonomous_database: Get detailed ADB with wallet info and auto-scaling

Updated README.md:
- Reorganized Database Systems section into subcategories
- Added Regular Databases and Autonomous Databases subsections
- Added comprehensive database usage examples
- Added v1.8 to Recent Improvements section
- Total MCP tools: 38 → 42 (+4 database tools)

Complete database ecosystem coverage:
- DB Systems (infrastructure)
- DB Nodes (node management)
- Databases (connection strings, PDB info)
- Autonomous Databases (wallet, auto-scaling, workload type)

All database functions were already implemented in database.py, now exposed as MCP tools with proper error handling and profile validation.