### PR TITLE
feat: Add Identity & Access Management tools (8 new tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,25 @@ Add this configuration to your file:
 - `set_oci_profile` - Activate a specific profile for API calls
 - `get_current_oci_profile` - Show currently active profile
 
-### **Identity & Access Management**
+### **Identity & Access Management** 🆕
+#### Compartments
 - `list_compartments` - List all compartments accessible to you
+
+#### Users
+- `list_users` - List all IAM users in a compartment with capabilities and MFA status
+- `get_user` - Get detailed user information including group memberships
+
+#### Groups
+- `list_groups` - List all IAM groups in a compartment with member count
+- `get_group` - Get detailed group information including members
+
+#### Policies
+- `list_policies` - List all IAM policies in a compartment with statements
+- `get_policy` - Get detailed policy information with all policy statements
+
+#### Dynamic Groups
+- `list_dynamic_groups` - List all dynamic groups with matching rules
+- `get_dynamic_group` - Get detailed dynamic group info with instance principal rules
 
 ### **Compute Resources**
 - `list_instances` - List virtual machine instances in a compartment
@@ -229,6 +246,37 @@ Add this configuration to your file:
 
 # Switch between tenancies
 "Switch to the DEFAULT profile"
+```
+
+### **Identity & Access Management** 🆕
+```bash
+# Users
+"List all IAM users in my tenancy"
+"Show me details for user ocid1.user.oc1..."
+"Does this user have MFA enabled?"
+"What groups is this user a member of?"
+
+# Groups
+"List all IAM groups in compartment X"
+"Show me members of group 'Administrators'"
+"Get details for group ocid1.group.oc1..."
+
+# Policies
+"List all IAM policies in the root compartment"
+"Show me policy statements for 'network-admins-policy'"
+"What permissions does this policy grant?"
+"Get details for policy ocid1.policy.oc1..."
+
+# Dynamic Groups
+"List all dynamic groups in my tenancy"
+"Show me matching rules for dynamic group 'instance-principals'"
+"What instances match this dynamic group?"
+"Get details for dynamic group ocid1.dynamicgroup.oc1..."
+
+# Security auditing
+"Which users have admin access?"
+"Show me all policies that grant object storage access"
+"What dynamic groups allow instance principals?"
 ```
 
 ### **Compute Instance Management**
@@ -324,7 +372,16 @@ Add this configuration to your file:
 
 ## 🚀 **Recent Improvements**
 
-### v1.8 - Database Tools (Latest) 🗄️
+### v1.9 - Identity & Access Management Tools (Latest) 🔐
+- **8 new IAM tools**: Users, Groups, Policies, Dynamic Groups
+- **Security auditing**: Review user capabilities, MFA status, and group memberships
+- **Policy management**: List and inspect all IAM policy statements
+- **Dynamic groups**: View instance principal matching rules
+- Essential for compliance, security audits, and access troubleshooting
+- Total MCP tools increased from 42 to 50
+- Added comprehensive IAM usage examples in README
+
+### v1.8 - Database Tools 🗄️
 - **4 new database tools**: Regular Databases and Autonomous Databases
 - **Regular Databases**: List/get databases with connection strings and PDB names
 - **Autonomous Databases**: List/get ADB with workload type, wallet info, and auto-scaling

--- a/mcp_server_oci/mcp_server.py
+++ b/mcp_server_oci/mcp_server.py
@@ -1012,6 +1012,158 @@ async def mcp_get_autonomous_database(ctx: Context, autonomous_database_id: str)
     return get_autonomous_database(oci_clients["database"], autonomous_database_id)
 
 
+# Identity & Access Management tools - Users
+@mcp.tool(name="list_users")
+@mcp_tool_wrapper(
+    start_msg="Listing IAM users in compartment {compartment_id}...",
+    error_prefix="Error listing users"
+)
+async def mcp_list_users(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all IAM users in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list users from
+
+    Returns:
+        List of users with their state, capabilities, and MFA status
+    """
+    return list_users(oci_clients["identity"], compartment_id)
+
+
+@mcp.tool(name="get_user")
+@mcp_tool_wrapper(
+    start_msg="Getting user details for {user_id}...",
+    success_msg="Retrieved user details successfully",
+    error_prefix="Error getting user details"
+)
+async def mcp_get_user(ctx: Context, user_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific IAM user.
+
+    Args:
+        user_id: OCID of the user to retrieve
+
+    Returns:
+        Detailed user information including capabilities, MFA status, and group memberships
+    """
+    return get_user(oci_clients["identity"], user_id)
+
+
+# Identity & Access Management tools - Groups
+@mcp.tool(name="list_groups")
+@mcp_tool_wrapper(
+    start_msg="Listing IAM groups in compartment {compartment_id}...",
+    error_prefix="Error listing groups"
+)
+async def mcp_list_groups(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all IAM groups in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list groups from
+
+    Returns:
+        List of groups with their members count and state
+    """
+    return list_groups(oci_clients["identity"], compartment_id)
+
+
+@mcp.tool(name="get_group")
+@mcp_tool_wrapper(
+    start_msg="Getting group details for {group_id}...",
+    success_msg="Retrieved group details successfully",
+    error_prefix="Error getting group details"
+)
+async def mcp_get_group(ctx: Context, group_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific IAM group.
+
+    Args:
+        group_id: OCID of the group to retrieve
+
+    Returns:
+        Detailed group information including members and description
+    """
+    return get_group(oci_clients["identity"], group_id)
+
+
+# Identity & Access Management tools - Policies
+@mcp.tool(name="list_policies")
+@mcp_tool_wrapper(
+    start_msg="Listing IAM policies in compartment {compartment_id}...",
+    error_prefix="Error listing policies"
+)
+async def mcp_list_policies(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all IAM policies in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list policies from
+
+    Returns:
+        List of policies with their statements and state
+    """
+    return list_policies(oci_clients["identity"], compartment_id)
+
+
+@mcp.tool(name="get_policy")
+@mcp_tool_wrapper(
+    start_msg="Getting policy details for {policy_id}...",
+    success_msg="Retrieved policy details successfully",
+    error_prefix="Error getting policy details"
+)
+async def mcp_get_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific IAM policy.
+
+    Args:
+        policy_id: OCID of the policy to retrieve
+
+    Returns:
+        Detailed policy information including all policy statements
+    """
+    return get_policy(oci_clients["identity"], policy_id)
+
+
+# Identity & Access Management tools - Dynamic Groups
+@mcp.tool(name="list_dynamic_groups")
+@mcp_tool_wrapper(
+    start_msg="Listing dynamic groups in compartment {compartment_id}...",
+    error_prefix="Error listing dynamic groups"
+)
+async def mcp_list_dynamic_groups(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all dynamic groups in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list dynamic groups from
+
+    Returns:
+        List of dynamic groups with their matching rules and state
+    """
+    return list_dynamic_groups(oci_clients["identity"], compartment_id)
+
+
+@mcp.tool(name="get_dynamic_group")
+@mcp_tool_wrapper(
+    start_msg="Getting dynamic group details for {dynamic_group_id}...",
+    success_msg="Retrieved dynamic group details successfully",
+    error_prefix="Error getting dynamic group details"
+)
+async def mcp_get_dynamic_group(ctx: Context, dynamic_group_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific dynamic group.
+
+    Args:
+        dynamic_group_id: OCID of the dynamic group to retrieve
+
+    Returns:
+        Detailed dynamic group information including matching rules for instance principals
+    """
+    return get_dynamic_group(oci_clients["identity"], dynamic_group_id)
+
+
 def main() -> None:
     """Run the MCP server for OCI."""
     global oci_clients, current_profile


### PR DESCRIPTION
Added 8 new MCP tools for IAM resources:

Users (2 tools):
- list_users: List IAM users with capabilities and MFA status
- get_user: Get detailed user info with group memberships

Groups (2 tools):
- list_groups: List IAM groups with member count
- get_group: Get detailed group info with members

Policies (2 tools):
- list_policies: List IAM policies with statements
- get_policy: Get detailed policy with all statements

Dynamic Groups (2 tools):
- list_dynamic_groups: List dynamic groups with matching rules
- get_dynamic_group: Get detailed dynamic group with instance principal rules

Updated README.md:
- Reorganized IAM section with subcategories (Compartments, Users, Groups, Policies, Dynamic Groups)
- Added comprehensive IAM usage examples
- Added security auditing examples
- Added v1.9 to Recent Improvements section
- Total MCP tools: 42 → 50 (+8 IAM tools)

Use cases enabled:
- Security auditing and compliance
- User capability and MFA verification
- Policy statement inspection
- Dynamic group and instance principal troubleshooting
- Access control review

All IAM functions were already implemented in identity.py, now exposed as MCP tools with proper error handling and profile validation.