### PR TITLE
feat: Add Load Balancer tools (v1.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,15 @@ Add this configuration to your file:
 - `list_file_systems` - List all File Storage file systems in a compartment and AD
 - `get_file_system` - Get detailed file system information including metered bytes and snapshots
 
+### **Load Balancers** 🆕
+#### Classic Load Balancers
+- `list_load_balancers` - List all classic load balancers in a compartment
+- `get_load_balancer` - Get detailed load balancer information including backend sets, listeners, and certificates
+
+#### Network Load Balancers
+- `list_network_load_balancers` - List all network load balancers in a compartment
+- `get_network_load_balancer` - Get detailed network load balancer information including backend sets and listeners
+
 ## 💡 **Usage Examples**
 
 ### **Profile Management**
@@ -359,6 +368,25 @@ Add this configuration to your file:
 "How many bytes is this file system using?"
 ```
 
+### **Load Balancer Management** 🆕
+```bash
+# Classic Load Balancers
+"List all load balancers in compartment X"
+"Show me details for load balancer ocid1.loadbalancer.oc1..."
+"What backend sets and listeners does this load balancer have?"
+"Show me health check configuration for this load balancer"
+
+# Network Load Balancers
+"List all network load balancers in compartment Y"
+"Show me details for network load balancer ocid1.networkloadbalancer.oc1..."
+"What is the backend configuration for this NLB?"
+"Is source IP preservation enabled on this network load balancer?"
+
+# Load balancer analysis
+"Show me all load balancers and their IP addresses"
+"Which load balancers are private vs public?"
+```
+
 ### **Resource Discovery**
 ```bash
 # List compartments
@@ -372,7 +400,15 @@ Add this configuration to your file:
 
 ## 🚀 **Recent Improvements**
 
-### v1.9 - Identity & Access Management Tools (Latest) 🔐
+### v1.10 - Load Balancer Tools (Latest) ⚖️
+- **4 new load balancer tools**: Classic Load Balancers and Network Load Balancers
+- **Classic Load Balancers**: List/get LBs with backend sets, listeners, and certificates
+- **Network Load Balancers**: List/get NLBs with backend configuration and IP preservation
+- Complete load balancing coverage: Layer 7 (classic) and Layer 4 (network) load balancers
+- Total MCP tools increased from 50 to 54
+- Added comprehensive load balancer usage examples in README
+
+### v1.9 - Identity & Access Management Tools 🔐
 - **8 new IAM tools**: Users, Groups, Policies, Dynamic Groups
 - **Security auditing**: Review user capabilities, MFA status, and group memberships
 - **Policy management**: List and inspect all IAM policy statements

--- a/mcp_server_oci/mcp_server.py
+++ b/mcp_server_oci/mcp_server.py
@@ -1164,6 +1164,82 @@ async def mcp_get_dynamic_group(ctx: Context, dynamic_group_id: str) -> Dict[str
     return get_dynamic_group(oci_clients["identity"], dynamic_group_id)
 
 
+# Load Balancer tools - Load Balancers
+@mcp.tool(name="list_load_balancers")
+@mcp_tool_wrapper(
+    start_msg="Listing load balancers in compartment {compartment_id}...",
+    error_prefix="Error listing load balancers"
+)
+async def mcp_list_load_balancers(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all classic load balancers in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list load balancers from
+
+    Returns:
+        List of load balancers with their IP addresses, shape, and state
+    """
+    return list_load_balancers(oci_clients["load_balancer"], compartment_id)
+
+
+@mcp.tool(name="get_load_balancer")
+@mcp_tool_wrapper(
+    start_msg="Getting load balancer details for {load_balancer_id}...",
+    success_msg="Retrieved load balancer details successfully",
+    error_prefix="Error getting load balancer details"
+)
+async def mcp_get_load_balancer(ctx: Context, load_balancer_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific classic load balancer.
+
+    Args:
+        load_balancer_id: OCID of the load balancer to retrieve
+
+    Returns:
+        Detailed load balancer information including backend sets, listeners, and certificates
+    """
+    return get_load_balancer(oci_clients["load_balancer"], load_balancer_id)
+
+
+# Load Balancer tools - Network Load Balancers
+@mcp.tool(name="list_network_load_balancers")
+@mcp_tool_wrapper(
+    start_msg="Listing network load balancers in compartment {compartment_id}...",
+    error_prefix="Error listing network load balancers"
+)
+async def mcp_list_network_load_balancers(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all network load balancers in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list network load balancers from
+
+    Returns:
+        List of network load balancers with their IP addresses and state
+    """
+    return list_network_load_balancers(oci_clients["network_load_balancer"], compartment_id)
+
+
+@mcp.tool(name="get_network_load_balancer")
+@mcp_tool_wrapper(
+    start_msg="Getting network load balancer details for {network_load_balancer_id}...",
+    success_msg="Retrieved network load balancer details successfully",
+    error_prefix="Error getting network load balancer details"
+)
+async def mcp_get_network_load_balancer(ctx: Context, network_load_balancer_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific network load balancer.
+
+    Args:
+        network_load_balancer_id: OCID of the network load balancer to retrieve
+
+    Returns:
+        Detailed network load balancer information including backend sets and listeners
+    """
+    return get_network_load_balancer(oci_clients["network_load_balancer"], network_load_balancer_id)
+
+
 def main() -> None:
     """Run the MCP server for OCI."""
     global oci_clients, current_profile


### PR DESCRIPTION
This commit adds complete load balancing support to the MCP server with 4 new tools:

Classic Load Balancers (Layer 7):
- list_load_balancers: List all classic LBs with IP addresses and shape
- get_load_balancer: Get detailed LB with backend sets, listeners, and certificates

Network Load Balancers (Layer 4):
- list_network_load_balancers: List all NLBs with IP addresses
- get_network_load_balancer: Get detailed NLB with backend config and IP preservation

Total MCP tools: 50 → 54

Updated README with:
- Load Balancers section with tool descriptions
- Load Balancer Management usage examples
- v1.10 in Recent Improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)