### PR TITLE
feat: Add Infrastructure Utilities (v1.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,22 @@ Add this configuration to your file:
 - `list_network_load_balancers` - List all network load balancers in a compartment
 - `get_network_load_balancer` - Get detailed network load balancer information including backend sets and listeners
 
+### **Infrastructure Utilities** 🆕
+#### Availability and Fault Domains
+- `list_availability_domains` - List all availability domains in a compartment
+- `list_fault_domains` - List all fault domains in an availability domain
+
+#### Compute Images
+- `list_images` - List all compute images with OS, version, and size
+- `get_image` - Get detailed image information including launch options
+
+#### Compute Shapes
+- `list_shapes` - List all compute shapes with CPU, memory, network, and GPU specs
+
+#### Regions and Tenancy
+- `list_regions` - List all available OCI regions
+- `get_tenancy_info` - Get tenancy details including name and home region
+
 ## 💡 **Usage Examples**
 
 ### **Profile Management**
@@ -387,6 +403,31 @@ Add this configuration to your file:
 "Which load balancers are private vs public?"
 ```
 
+### **Infrastructure Utilities** 🆕
+```bash
+# Availability and Fault Domains
+"List all availability domains in my tenancy"
+"Show me fault domains in availability domain AD-1"
+"What availability domains are available in region us-ashburn-1?"
+
+# Compute Images
+"List all compute images in compartment X"
+"Show me details for image ocid1.image.oc1..."
+"What Oracle Linux images are available?"
+"What is the size and OS version of this image?"
+
+# Compute Shapes
+"List all compute shapes available in compartment Y"
+"What shapes support GPU?"
+"Show me flexible shapes with configurable OCPUs"
+"What is the memory and network bandwidth for shape VM.Standard.E4.Flex?"
+
+# Regions and Tenancy
+"List all available OCI regions"
+"What is my tenancy name and home region?"
+"Show me tenancy information"
+```
+
 ### **Resource Discovery**
 ```bash
 # List compartments
@@ -400,7 +441,17 @@ Add this configuration to your file:
 
 ## 🚀 **Recent Improvements**
 
-### v1.10 - Load Balancer Tools (Latest) ⚖️
+### v1.11 - Infrastructure Utilities (Latest) 🏗️
+- **7 new infrastructure tools**: Availability Domains, Fault Domains, Images, Shapes, Regions, and Tenancy
+- **Availability/Fault Domains**: List ADs and FDs for high availability planning
+- **Compute Images**: List/get images with OS versions and launch options
+- **Compute Shapes**: List shapes with CPU, memory, network, and GPU specifications
+- **Regions & Tenancy**: List all regions and get tenancy information
+- Essential for resource planning, capacity management, and infrastructure discovery
+- Total MCP tools increased from 54 to 61
+- Added comprehensive infrastructure utilities usage examples in README
+
+### v1.10 - Load Balancer Tools ⚖️
 - **4 new load balancer tools**: Classic Load Balancers and Network Load Balancers
 - **Classic Load Balancers**: List/get LBs with backend sets, listeners, and certificates
 - **Network Load Balancers**: List/get NLBs with backend configuration and IP preservation

--- a/mcp_server_oci/mcp_server.py
+++ b/mcp_server_oci/mcp_server.py
@@ -1240,6 +1240,136 @@ async def mcp_get_network_load_balancer(ctx: Context, network_load_balancer_id: 
     return get_network_load_balancer(oci_clients["network_load_balancer"], network_load_balancer_id)
 
 
+# Infrastructure Utilities - Availability and Fault Domains
+@mcp.tool(name="list_availability_domains")
+@mcp_tool_wrapper(
+    start_msg="Listing availability domains in compartment {compartment_id}...",
+    error_prefix="Error listing availability domains"
+)
+async def mcp_list_availability_domains(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all availability domains in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment (typically use tenancy OCID for root)
+
+    Returns:
+        List of availability domains with their names and IDs
+    """
+    return list_availability_domains(oci_clients["identity"], compartment_id)
+
+
+@mcp.tool(name="list_fault_domains")
+@mcp_tool_wrapper(
+    start_msg="Listing fault domains in availability domain {availability_domain}...",
+    error_prefix="Error listing fault domains"
+)
+async def mcp_list_fault_domains(ctx: Context, compartment_id: str, availability_domain: str) -> List[Dict[str, Any]]:
+    """
+    List all fault domains in an availability domain.
+
+    Args:
+        compartment_id: OCID of the compartment
+        availability_domain: Name of the availability domain
+
+    Returns:
+        List of fault domains with their names and IDs
+    """
+    return list_fault_domains(oci_clients["identity"], compartment_id, availability_domain)
+
+
+# Infrastructure Utilities - Compute Images
+@mcp.tool(name="list_images")
+@mcp_tool_wrapper(
+    start_msg="Listing compute images in compartment {compartment_id}...",
+    error_prefix="Error listing images"
+)
+async def mcp_list_images(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all compute images in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list images from
+
+    Returns:
+        List of images with OS, version, size, and lifecycle state
+    """
+    return list_images(oci_clients["compute"], compartment_id)
+
+
+@mcp.tool(name="get_image")
+@mcp_tool_wrapper(
+    start_msg="Getting image details for {image_id}...",
+    success_msg="Retrieved image details successfully",
+    error_prefix="Error getting image details"
+)
+async def mcp_get_image(ctx: Context, image_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific compute image.
+
+    Args:
+        image_id: OCID of the image to retrieve
+
+    Returns:
+        Detailed image information including launch options and OS details
+    """
+    return get_image(oci_clients["compute"], image_id)
+
+
+# Infrastructure Utilities - Compute Shapes
+@mcp.tool(name="list_shapes")
+@mcp_tool_wrapper(
+    start_msg="Listing compute shapes in compartment {compartment_id}...",
+    error_prefix="Error listing shapes"
+)
+async def mcp_list_shapes(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all compute shapes available in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment
+
+    Returns:
+        List of shapes with CPU, memory, network, and GPU specifications
+    """
+    return list_shapes(oci_clients["compute"], compartment_id)
+
+
+# Infrastructure Utilities - Regions and Tenancy
+@mcp.tool(name="list_regions")
+@mcp_tool_wrapper(
+    start_msg="Listing all available OCI regions...",
+    error_prefix="Error listing regions"
+)
+async def mcp_list_regions(ctx: Context) -> List[Dict[str, Any]]:
+    """
+    List all available OCI regions.
+
+    Returns:
+        List of regions with their keys and names
+    """
+    return list_regions(oci_clients["identity"])
+
+
+@mcp.tool(name="get_tenancy_info")
+@mcp_tool_wrapper(
+    start_msg="Getting tenancy information for {tenancy_id}...",
+    success_msg="Retrieved tenancy information successfully",
+    error_prefix="Error getting tenancy information"
+)
+async def mcp_get_tenancy_info(ctx: Context, tenancy_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a tenancy.
+
+    Args:
+        tenancy_id: OCID of the tenancy
+
+    Returns:
+        Tenancy details including name, home region, and description
+    """
+    return get_tenancy_info(oci_clients["identity"], tenancy_id)
+
+
 def main() -> None:
     """Run the MCP server for OCI."""
     global oci_clients, current_profile


### PR DESCRIPTION
This commit adds comprehensive infrastructure discovery and planning tools with 7 new MCP tools:

Availability and Fault Domains:
- list_availability_domains: List all ADs for high availability planning
- list_fault_domains: List FDs within an AD for fault tolerance

Compute Images:
- list_images: List all compute images with OS, version, and size
- get_image: Get detailed image info with launch options

Compute Shapes:
- list_shapes: List shapes with CPU, memory, network, and GPU specs

Regions and Tenancy:
- list_regions: List all available OCI regions
- get_tenancy_info: Get tenancy details including name and home region

Total MCP tools: 54 → 61

Updated README with:
- Infrastructure Utilities section with tool descriptions
- Infrastructure Utilities usage examples covering ADs, images, shapes, and regions
- v1.11 in Recent Improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)