### PR TITLE
feat: Add Cost Management tools (v1.13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,16 @@ Add this configuration to your file:
 - `list_regions` - List all available OCI regions
 - `get_tenancy_info` - Get tenancy details including name and home region
 
+### **Cost Management** 🆕
+#### Usage and Cost Analysis
+- `get_cost_usage_summary` - Get cost and usage summary for a tenancy with daily or monthly granularity
+- `get_cost_by_service` - Get cost breakdown by service for a specified time period
+- `get_cost_by_compartment` - Get cost breakdown by compartment for a specified time period
+
+#### Budgets
+- `list_budgets` - List all budgets with amount, actual spend, and forecasted spend
+- `get_budget` - Get detailed budget information including targets and alert rules
+
 ## 💡 **Usage Examples**
 
 ### **Profile Management**
@@ -428,6 +438,27 @@ Add this configuration to your file:
 "Show me tenancy information"
 ```
 
+### **Cost Management** 🆕
+```bash
+# Usage and Cost Analysis
+"Show me cost and usage summary for the last 30 days"
+"Get cost breakdown by service from 2024-01-01 to 2024-01-31"
+"What are my costs by compartment for this month?"
+"Show me daily cost summary for my tenancy"
+
+# Cost analysis queries
+"Which services are costing the most?"
+"What compartment has the highest spend?"
+"Show me monthly cost trends"
+
+# Budgets
+"List all budgets in compartment X"
+"Show me budget details for budget ocid1.budget.oc1..."
+"What is my actual spend vs budget?"
+"Show me forecasted spend for this budget"
+"Which budgets have alert rules configured?"
+```
+
 ### **Resource Discovery**
 ```bash
 # List compartments
@@ -441,7 +472,16 @@ Add this configuration to your file:
 
 ## 🚀 **Recent Improvements**
 
-### v1.11 - Infrastructure Utilities (Latest) 🏗️
+### v1.13 - Cost Management Tools (Latest) 💰
+- **5 new cost management tools**: Usage/Cost Analysis and Budgets
+- **Usage Analysis**: Get cost summaries with daily/monthly granularity
+- **Cost Breakdown**: Analyze costs by service or compartment for any time period
+- **Budget Management**: List/get budgets with actual spend, forecasted spend, and alert rules
+- Essential for cost optimization, budget tracking, and financial governance
+- Total MCP tools increased from 61 to 66
+- Added comprehensive cost management usage examples in README
+
+### v1.11 - Infrastructure Utilities 🏗️
 - **7 new infrastructure tools**: Availability Domains, Fault Domains, Images, Shapes, Regions, and Tenancy
 - **Availability/Fault Domains**: List ADs and FDs for high availability planning
 - **Compute Images**: List/get images with OS versions and launch options

--- a/mcp_server_oci/mcp_server.py
+++ b/mcp_server_oci/mcp_server.py
@@ -92,6 +92,13 @@ from mcp_server_oci.tools.resources import (
     list_regions,
     get_tenancy_info,
 )
+from mcp_server_oci.tools.cost import (
+    get_cost_usage_summary,
+    get_cost_by_service,
+    get_cost_by_compartment,
+    list_budgets,
+    get_budget,
+)
 # DB Systems tools (our corrected module)
 from mcp_server_oci.tools.dbsystems import (
     list_db_systems,
@@ -235,6 +242,8 @@ def init_oci_clients(profile: str = "DEFAULT") -> Dict[str, Any]:
         load_balancer_client = oci.load_balancer.LoadBalancerClient(config)
         network_load_balancer_client = oci.network_load_balancer.NetworkLoadBalancerClient(config)
         kms_vault_client = oci.key_management.KmsVaultClient(config)
+        usage_api_client = oci.usage_api.UsageapiClient(config)
+        budget_client = oci.budget.BudgetClient(config)
 
         oci_clients = {
             "compute": compute_client,
@@ -247,6 +256,8 @@ def init_oci_clients(profile: str = "DEFAULT") -> Dict[str, Any]:
             "load_balancer": load_balancer_client,
             "network_load_balancer": network_load_balancer_client,
             "kms_vault": kms_vault_client,
+            "usage_api": usage_api_client,
+            "budget": budget_client,
             "config": config,
         }
 
@@ -1368,6 +1379,110 @@ async def mcp_get_tenancy_info(ctx: Context, tenancy_id: str) -> Dict[str, Any]:
         Tenancy details including name, home region, and description
     """
     return get_tenancy_info(oci_clients["identity"], tenancy_id)
+
+
+# Cost Management - Usage and Cost Analysis
+@mcp.tool(name="get_cost_usage_summary")
+@mcp_tool_wrapper(
+    start_msg="Getting cost and usage summary...",
+    error_prefix="Error getting cost usage summary"
+)
+async def mcp_get_cost_usage_summary(ctx: Context, tenant_id: str, time_usage_started: str,
+                                    time_usage_ended: str, granularity: str = "DAILY") -> List[Dict[str, Any]]:
+    """
+    Get cost and usage summary for a tenancy.
+
+    Args:
+        tenant_id: OCID of the tenancy
+        time_usage_started: Start time in ISO format (YYYY-MM-DD)
+        time_usage_ended: End time in ISO format (YYYY-MM-DD)
+        granularity: Granularity of the data (DAILY or MONTHLY), defaults to DAILY
+
+    Returns:
+        List of cost and usage summaries with amounts, services, and compartments
+    """
+    return get_cost_usage_summary(oci_clients["usage_api"], tenant_id, time_usage_started,
+                                 time_usage_ended, granularity)
+
+
+@mcp.tool(name="get_cost_by_service")
+@mcp_tool_wrapper(
+    start_msg="Getting cost breakdown by service...",
+    error_prefix="Error getting cost by service"
+)
+async def mcp_get_cost_by_service(ctx: Context, tenant_id: str, time_usage_started: str,
+                                  time_usage_ended: str) -> List[Dict[str, Any]]:
+    """
+    Get cost breakdown by service for a tenancy.
+
+    Args:
+        tenant_id: OCID of the tenancy
+        time_usage_started: Start time in ISO format (YYYY-MM-DD)
+        time_usage_ended: End time in ISO format (YYYY-MM-DD)
+
+    Returns:
+        List of costs grouped by service with total cost per service
+    """
+    return get_cost_by_service(oci_clients["usage_api"], tenant_id, time_usage_started, time_usage_ended)
+
+
+@mcp.tool(name="get_cost_by_compartment")
+@mcp_tool_wrapper(
+    start_msg="Getting cost breakdown by compartment...",
+    error_prefix="Error getting cost by compartment"
+)
+async def mcp_get_cost_by_compartment(ctx: Context, tenant_id: str, time_usage_started: str,
+                                      time_usage_ended: str) -> List[Dict[str, Any]]:
+    """
+    Get cost breakdown by compartment for a tenancy.
+
+    Args:
+        tenant_id: OCID of the tenancy
+        time_usage_started: Start time in ISO format (YYYY-MM-DD)
+        time_usage_ended: End time in ISO format (YYYY-MM-DD)
+
+    Returns:
+        List of costs grouped by compartment with total cost per compartment
+    """
+    return get_cost_by_compartment(oci_clients["usage_api"], tenant_id, time_usage_started, time_usage_ended)
+
+
+# Cost Management - Budgets
+@mcp.tool(name="list_budgets")
+@mcp_tool_wrapper(
+    start_msg="Listing budgets in compartment {compartment_id}...",
+    error_prefix="Error listing budgets"
+)
+async def mcp_list_budgets(ctx: Context, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all budgets in a compartment.
+
+    Args:
+        compartment_id: OCID of the compartment to list budgets from
+
+    Returns:
+        List of budgets with amount, reset period, actual spend, and forecasted spend
+    """
+    return list_budgets(oci_clients["budget"], compartment_id)
+
+
+@mcp.tool(name="get_budget")
+@mcp_tool_wrapper(
+    start_msg="Getting budget details for {budget_id}...",
+    success_msg="Retrieved budget details successfully",
+    error_prefix="Error getting budget details"
+)
+async def mcp_get_budget(ctx: Context, budget_id: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific budget.
+
+    Args:
+        budget_id: OCID of the budget to retrieve
+
+    Returns:
+        Detailed budget information including targets, alert rules, and spend tracking
+    """
+    return get_budget(oci_clients["budget"], budget_id)
 
 
 def main() -> None:

--- a/mcp_server_oci/tools/cost.py
+++ b/mcp_server_oci/tools/cost.py
@@ -1,0 +1,256 @@
+"""
+Tools for managing OCI Cost Management and Usage resources.
+"""
+
+import logging
+from typing import Dict, List, Any, Optional
+from datetime import datetime, timedelta
+
+import oci
+
+logger = logging.getLogger(__name__)
+
+
+def get_cost_usage_summary(usage_api_client: oci.usage_api.UsageapiClient,
+                           tenant_id: str,
+                           time_usage_started: str,
+                           time_usage_ended: str,
+                           granularity: str = "DAILY") -> List[Dict[str, Any]]:
+    """
+    Get cost and usage summary for a tenancy.
+
+    Args:
+        usage_api_client: OCI UsageApi client
+        tenant_id: OCID of the tenancy
+        time_usage_started: Start time in ISO format (YYYY-MM-DD)
+        time_usage_ended: End time in ISO format (YYYY-MM-DD)
+        granularity: Granularity of the data (DAILY, MONTHLY)
+
+    Returns:
+        List of cost and usage summaries
+    """
+    try:
+        request_summarized_usages_details = oci.usage_api.models.RequestSummarizedUsagesDetails(
+            tenant_id=tenant_id,
+            time_usage_started=time_usage_started,
+            time_usage_ended=time_usage_ended,
+            granularity=granularity,
+            is_aggregate_by_time=True
+        )
+
+        usage_response = oci.pagination.list_call_get_all_results(
+            usage_api_client.request_summarized_usages,
+            request_summarized_usages_details=request_summarized_usages_details
+        )
+
+        summaries = []
+        for item in usage_response.data.items:
+            summaries.append({
+                "time_usage_started": str(item.time_usage_started),
+                "time_usage_ended": str(item.time_usage_ended),
+                "computed_amount": item.computed_amount,
+                "computed_quantity": item.computed_quantity,
+                "currency": item.currency,
+                "service": item.service,
+                "resource_name": item.resource_name,
+                "compartment_name": item.compartment_name,
+                "compartment_id": item.compartment_id,
+                "unit": item.unit,
+            })
+
+        logger.info(f"Retrieved {len(summaries)} usage summaries for tenancy {tenant_id}")
+        return summaries
+
+    except Exception as e:
+        logger.exception(f"Error getting cost usage summary: {e}")
+        raise
+
+
+def get_cost_by_service(usage_api_client: oci.usage_api.UsageapiClient,
+                       tenant_id: str,
+                       time_usage_started: str,
+                       time_usage_ended: str) -> List[Dict[str, Any]]:
+    """
+    Get cost breakdown by service.
+
+    Args:
+        usage_api_client: OCI UsageApi client
+        tenant_id: OCID of the tenancy
+        time_usage_started: Start time in ISO format (YYYY-MM-DD)
+        time_usage_ended: End time in ISO format (YYYY-MM-DD)
+
+    Returns:
+        List of costs grouped by service
+    """
+    try:
+        request_summarized_usages_details = oci.usage_api.models.RequestSummarizedUsagesDetails(
+            tenant_id=tenant_id,
+            time_usage_started=time_usage_started,
+            time_usage_ended=time_usage_ended,
+            granularity="DAILY",
+            group_by=["service"]
+        )
+
+        usage_response = oci.pagination.list_call_get_all_results(
+            usage_api_client.request_summarized_usages,
+            request_summarized_usages_details=request_summarized_usages_details
+        )
+
+        # Aggregate by service
+        service_costs = {}
+        for item in usage_response.data.items:
+            service = item.service
+            if service not in service_costs:
+                service_costs[service] = {
+                    "service": service,
+                    "total_cost": 0.0,
+                    "currency": item.currency,
+                    "unit": item.unit,
+                }
+            service_costs[service]["total_cost"] += float(item.computed_amount) if item.computed_amount else 0.0
+
+        result = list(service_costs.values())
+        logger.info(f"Retrieved cost breakdown for {len(result)} services")
+        return result
+
+    except Exception as e:
+        logger.exception(f"Error getting cost by service: {e}")
+        raise
+
+
+def get_cost_by_compartment(usage_api_client: oci.usage_api.UsageapiClient,
+                            tenant_id: str,
+                            time_usage_started: str,
+                            time_usage_ended: str) -> List[Dict[str, Any]]:
+    """
+    Get cost breakdown by compartment.
+
+    Args:
+        usage_api_client: OCI UsageApi client
+        tenant_id: OCID of the tenancy
+        time_usage_started: Start time in ISO format (YYYY-MM-DD)
+        time_usage_ended: End time in ISO format (YYYY-MM-DD)
+
+    Returns:
+        List of costs grouped by compartment
+    """
+    try:
+        request_summarized_usages_details = oci.usage_api.models.RequestSummarizedUsagesDetails(
+            tenant_id=tenant_id,
+            time_usage_started=time_usage_started,
+            time_usage_ended=time_usage_ended,
+            granularity="DAILY",
+            group_by=["compartmentName"]
+        )
+
+        usage_response = oci.pagination.list_call_get_all_results(
+            usage_api_client.request_summarized_usages,
+            request_summarized_usages_details=request_summarized_usages_details
+        )
+
+        # Aggregate by compartment
+        compartment_costs = {}
+        for item in usage_response.data.items:
+            compartment = item.compartment_name
+            if compartment not in compartment_costs:
+                compartment_costs[compartment] = {
+                    "compartment_name": compartment,
+                    "compartment_id": item.compartment_id,
+                    "total_cost": 0.0,
+                    "currency": item.currency,
+                }
+            compartment_costs[compartment]["total_cost"] += float(item.computed_amount) if item.computed_amount else 0.0
+
+        result = list(compartment_costs.values())
+        logger.info(f"Retrieved cost breakdown for {len(result)} compartments")
+        return result
+
+    except Exception as e:
+        logger.exception(f"Error getting cost by compartment: {e}")
+        raise
+
+
+def list_budgets(budget_client: oci.budget.BudgetClient, compartment_id: str) -> List[Dict[str, Any]]:
+    """
+    List all budgets in a compartment.
+
+    Args:
+        budget_client: OCI Budget client
+        compartment_id: OCID of the compartment
+
+    Returns:
+        List of budgets with their details
+    """
+    try:
+        budgets_response = oci.pagination.list_call_get_all_results(
+            budget_client.list_budgets,
+            compartment_id
+        )
+
+        budgets = []
+        for budget in budgets_response.data:
+            budgets.append({
+                "id": budget.id,
+                "display_name": budget.display_name,
+                "compartment_id": budget.compartment_id,
+                "target_compartment_id": budget.target_compartment_id,
+                "amount": budget.amount,
+                "reset_period": budget.reset_period,
+                "lifecycle_state": budget.lifecycle_state,
+                "alert_rule_count": budget.alert_rule_count,
+                "time_created": str(budget.time_created),
+                "actual_spend": budget.actual_spend,
+                "forecasted_spend": budget.forecasted_spend,
+                "time_spend_computed": str(budget.time_spend_computed) if budget.time_spend_computed else None,
+            })
+
+        logger.info(f"Found {len(budgets)} budgets in compartment {compartment_id}")
+        return budgets
+
+    except Exception as e:
+        logger.exception(f"Error listing budgets: {e}")
+        raise
+
+
+def get_budget(budget_client: oci.budget.BudgetClient, budget_id: str) -> Dict[str, Any]:
+    """
+    Get details of a specific budget.
+
+    Args:
+        budget_client: OCI Budget client
+        budget_id: OCID of the budget
+
+    Returns:
+        Details of the budget
+    """
+    try:
+        budget = budget_client.get_budget(budget_id).data
+
+        budget_details = {
+            "id": budget.id,
+            "display_name": budget.display_name,
+            "description": budget.description,
+            "compartment_id": budget.compartment_id,
+            "target_compartment_id": budget.target_compartment_id,
+            "target_type": budget.target_type,
+            "targets": budget.targets,
+            "amount": budget.amount,
+            "reset_period": budget.reset_period,
+            "budget_processing_period_start_offset": budget.budget_processing_period_start_offset,
+            "processing_period_type": budget.processing_period_type,
+            "lifecycle_state": budget.lifecycle_state,
+            "alert_rule_count": budget.alert_rule_count,
+            "version": budget.version,
+            "actual_spend": budget.actual_spend,
+            "forecasted_spend": budget.forecasted_spend,
+            "time_spend_computed": str(budget.time_spend_computed) if budget.time_spend_computed else None,
+            "time_created": str(budget.time_created),
+            "time_updated": str(budget.time_updated),
+        }
+
+        logger.info(f"Retrieved details for budget {budget_id}")
+        return budget_details
+
+    except Exception as e:
+        logger.exception(f"Error getting budget details: {e}")
+        raise


### PR DESCRIPTION
This commit adds comprehensive cost analysis and budget management with 5 new tools:

Usage and Cost Analysis:
- get_cost_usage_summary: Get cost/usage summary with daily or monthly granularity
- get_cost_by_service: Analyze costs grouped by service
- get_cost_by_compartment: Analyze costs grouped by compartment

Budget Management:
- list_budgets: List budgets with amount, actual spend, and forecasted spend
- get_budget: Get detailed budget info including targets and alert rules

Technical improvements:
- Created new cost.py module with usage and budget functions
- Added UsageApi and Budget clients to OCI client initialization
- All cost tools support ISO date format (YYYY-MM-DD) for time ranges

Total MCP tools: 61 → 66

Updated README with:
- Cost Management section with tool descriptions
- Cost Management usage examples covering cost analysis and budgets
- v1.13 in Recent Improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)